### PR TITLE
feat: normalize huue/xvve variations to хөөе

### DIFF
--- a/cf-worker/src/normalize.js
+++ b/cf-worker/src/normalize.js
@@ -1,5 +1,32 @@
-import { normalize } from "./lib/normalize.js";
-
 export function normalize(text) {
-  return text.toLowerCase().trim();
+  const t = text.toLowerCase().trim();
+
+  const mapping = {
+    huue: "Å¡oíy",
+    hue: "Å¡oíy",
+    hoye: "Å¡oíy",
+    huuie: "Å¡oíy",
+    huuye: "Å¡oíy",
+    hooie: "Å¡oíy",
+    hooe: "Å¡oíy",
+    hvue: "Å¡oíy",
+    hvve: "Å¡oíy",
+    hvuye: "Å¡oíy",
+    hvuie: "Å¡oíy",
+    hovee: "Å¡oíy",
+    xvve: "Å¡oíy",
+    xvvye: "Å¡oíy",
+    xvvie: "Å¡oíy",
+    xvvyee: "Å¡oíy",
+    Å¡oÅ—áy: "Å¡oíy",
+    "Å¡oï±q: "Å¡oíy",
+    â€›Å¡oï±q: "Å¡oíy",
+    â€›Å¡oï±q: "Å¡oíy",
+    â€›Å¡o.: "Å¡oíy"
+  };
+
+  if (mapping[t]) {
+    return mapping[t];
   }
+  return t;
+}


### PR DESCRIPTION
Added mapping in `normalize.js` so that variations like `huue`, `xvve`, `hvve`, `хуе` etc. are normalized to `хөөе`.